### PR TITLE
CI: Popravka putanje za dotnet restore/build/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,20 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
+        working-directory: src/PozoristeRepertoar
+
+
 
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build --no-restore
+        working-directory: src/PozoristeRepertoar
+
 
       - name: Run tests
-        run: |
+        run: | 
           dotnet test --no-build --verbosity normal || true
+        working-directory: src/PozoristeRepertoar
+
 
       - name: Upload build artifacts (optional)
         if: always()


### PR DESCRIPTION
Ispravljen GitHub Actions workflow (.NET CI) tako da dotnet restore/build/test rade iz foldera src/PozoristeRepertoar.

Ovo rešava grešku MSB1003 (nema .sln/.csproj u working directory).

